### PR TITLE
You already set type

### DIFF
--- a/public/contact.php
+++ b/public/contact.php
@@ -34,7 +34,6 @@ $ticket_data = [
     'customer_id' =>  "guess:" . htmlspecialchars($_POST['email']),
     'type'        => 'email',
     'article'     => [
-        'type_id' => 1,
         'from'    =>  htmlspecialchars($_POST['name']).' <'. htmlspecialchars($_POST['email']).'>',
         'to'      => 'PrevHelp Support',
         'subject' =>  htmlspecialchars($_POST['subject']),


### PR DESCRIPTION
You already set `type` to the value `email`. I think setting `type_id` is redundant and might cause misconfiguration in the future. 